### PR TITLE
better typing for projects

### DIFF
--- a/data/projects/anon-aadhaar.ts
+++ b/data/projects/anon-aadhaar.ts
@@ -17,7 +17,7 @@ export const anonAadhaar: ProjectInterface = {
   tags: {
     keywords: ["Anonymity/privacy", "Social", "Identity", "Voting/governance"],
     themes: ["build", "play"],
-    type: ["Legos/dev tools", "Lego sets/toolkits", "Proof of concept"],
+    types: ["Legos/dev tools", "Lego sets/toolkits", "Proof of concept"],
     builtWith: ["circom", "rsa"],
   },
 }

--- a/data/projects/anon-klub.ts
+++ b/data/projects/anon-klub.ts
@@ -24,7 +24,7 @@ export const anonKlub: ProjectInterface = {
       "Voting/governance",
     ],
     themes: ["build", "play"],
-    type: ["Infrastructure/protocol", "Prototype", "Proof of concept"],
+    types: ["Infrastructure/protocol", "Prototype", "Proof of concept"],
     builtWith: ["circom", "snarkjs", "halo2"],
   },
 }

--- a/data/projects/bandada.ts
+++ b/data/projects/bandada.ts
@@ -27,7 +27,7 @@ export const bandada: ProjectInterface = {
       "Scaling",
       "Key management",
     ],
-    type: [
+    types: [
       "Legos/dev tools",
       "Lego sets/toolkits",
       "Prototype",

--- a/data/projects/channel-4.ts
+++ b/data/projects/channel-4.ts
@@ -19,7 +19,7 @@ export const channel4: ProjectInterface = {
   tags: {
     keywords: ["Scaling"],
     themes: ["play"],
-    type: ["Application"],
+    types: ["Application"],
     builtWith: ["state channel", "smart contract"],
   },
 }

--- a/data/projects/dsl-working-group.ts
+++ b/data/projects/dsl-working-group.ts
@@ -15,7 +15,7 @@ export const dslWorkingGroup: ProjectInterface = {
     github: "https://github.com/privacy-scaling-explorations/chiquito/",
   },
   tags: {
-    type: ["Legos/dev tools", "Proof of concept", "Developer tooling"],
+    types: ["Legos/dev tools", "Proof of concept", "Developer tooling"],
     keywords: [],
     themes: ["research"],
     builtWith: [],

--- a/data/projects/eigen-trust.ts
+++ b/data/projects/eigen-trust.ts
@@ -17,7 +17,7 @@ export const eigenTrust: ProjectInterface = {
   tags: {
     keywords: ["Reputation", "Identity"],
     themes: ["build"],
-    type: ["Infrastructure/protocol"],
+    types: ["Infrastructure/protocol"],
     builtWith: ["ethereum attestation service", "halo2", "ethers.rs"],
   },
 }

--- a/data/projects/pollen-labs.ts
+++ b/data/projects/pollen-labs.ts
@@ -18,7 +18,7 @@ export const pollenLabs: ProjectInterface = {
   tags: {
     keywords: ["Anonymity/privacy", "Scaling"],
     themes: ["play"],
-    type: ["Application"],
+    types: ["Application"],
     builtWith: [],
   },
 }

--- a/data/projects/summa.ts
+++ b/data/projects/summa.ts
@@ -17,7 +17,7 @@ export const summa: ProjectInterface = {
   tags: {
     keywords: ["Anonymity/privacy", "Computational Integrity"],
     themes: ["build", "play"],
-    type: ["Infrastructure/protocol", "Application"],
+    types: ["Infrastructure/protocol", "Application"],
     builtWith: ["halo2"],
   },
 }

--- a/data/projects/tlsn.ts
+++ b/data/projects/tlsn.ts
@@ -18,7 +18,7 @@ export const tlsn: ProjectInterface = {
   },
   tags: {
     themes: ["build"],
-    type: [],
+    types: [],
     builtWith: [],
     keywords: [],
   },

--- a/data/projects/trusted-setups.ts
+++ b/data/projects/trusted-setups.ts
@@ -15,7 +15,7 @@ export const trustedSetups: ProjectInterface = {
   },
   tags: {
     themes: ["play"],
-    type: ["Legos/dev tools", "Lego sets/toolkits"],
+    types: ["Legos/dev tools", "Lego sets/toolkits"],
     builtWith: [],
     keywords: ["Scaling", "Education"],
   },

--- a/data/projects/unirep-protocol.ts
+++ b/data/projects/unirep-protocol.ts
@@ -20,7 +20,7 @@ export const unirepProtocol: ProjectInterface = {
   tags: {
     keywords: ["Anonymity/privacy", "Social", "Identity", "Reputation"],
     themes: ["build"],
-    type: ["Legos/dev tools, Protocol"],
+    types: ["Legos/dev tools, Protocol"],
     builtWith: ["semaphore", "circom"],
   },
 }

--- a/data/projects/zk3.ts
+++ b/data/projects/zk3.ts
@@ -18,7 +18,7 @@ export const zk3: ProjectInterface = {
   },
   tags: {
     themes: ["play"],
-    type: [
+    types: [
       "Legos/dev tools",
       "Lego sets/toolkits",
       "Infrastructure/protocol",

--- a/data/projects/zkml.ts
+++ b/data/projects/zkml.ts
@@ -17,7 +17,7 @@ export const zkml: ProjectInterface = {
   tags: {
     keywords: ["Anonymity/privacy", "Scaling"],
     themes: ["research"],
-    type: ["Proof of concept", "Infrastructure/protocol"],
+    types: ["Proof of concept", "Infrastructure/protocol"],
     builtWith: ["circom", "halo2", "nova"],
   },
 }

--- a/data/projects/zkp2p.ts
+++ b/data/projects/zkp2p.ts
@@ -18,8 +18,8 @@ export const zkp2p: ProjectInterface = {
   },
   tags: {
     keywords: ["Private communications"],
-    theme: ["play"],
-    type: ["Proof of concept", "Application"],
+    themes: ["play"],
+    types: ["Proof of concept", "Application"],
     builtWith: ["circom", "halo2"],
   },
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -19,6 +19,8 @@ export type ProjectLinkWebsite =
 
 export type ProjectLinkType = Partial<Record<ProjectLinkWebsite, string>>
 export type ProjectExtraLinkType = "buildWith" | "play" | "research" | "learn"
+export type TagType = "types" | "themes" | "builtWith" | "keywords"
+export type ProjectTags = Partial<Record<TagType, string[]>>
 export type ActionLinkTypeLink = {
   label: string
   url: string
@@ -36,6 +38,6 @@ export interface ProjectInterface {
   description: string
   links?: ProjectLinkType
   projectStatus: ProjectStatusType
-  tags?: Record<string, string[]>
+  tags?: ProjectTags
   extraLinks?: ActionLinkType
 }


### PR DESCRIPTION
`tags` on the project have a mismatch; for some, we have `types` for some and `type` for others.
This PR adds better typing in order to force to write the correct tag keys 