### PR TITLE
Updated hyperlink for the accelerator program

### DIFF
--- a/config/site.ts
+++ b/config/site.ts
@@ -23,7 +23,7 @@ export const siteConfig = {
     discordAnnouncementChannel:
       "https://discord.com/channels/943612659163602974/969614451089227876",
     acceleratorProgram:
-      "https://github.com/privacy-scaling-explorations/acceleration-program/issues/new?assignees=&labels=&projects=&template=propose-your-open-task.md&title=",
+      "https://github.com/privacy-scaling-explorations/acceleration-program",
     coreProgram:
       "https://docs.google.com/forms/d/e/1FAIpQLSendzYY0z_z7fZ37g3jmydvzS9I7OWKbY2JrqAnyNqeaBHvMQ/viewform",
   },


### PR DESCRIPTION
I've changed the URL for the 'Learn more on GitHub' call to action, this new link is where we would like applicants to go.